### PR TITLE
Handle connection timeout

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,6 +7,7 @@ module.exports = {
   testMatch: ["<rootDir>/src/**/*.test.{js,ts}"],
   collectCoverageFrom: [
     "src/**/*.ts",
+    "!src/executionHandler.ts",
     "!src/index.ts",
     "!src/@jupiterone/snyk-client.d.ts",
   ],

--- a/src/executionHandler.ts
+++ b/src/executionHandler.ts
@@ -1,4 +1,5 @@
 import {
+  IntegrationError,
   IntegrationExecutionContext,
   IntegrationExecutionResult,
 } from "@jupiterone/jupiter-managed-integration-sdk";
@@ -8,5 +9,18 @@ import synchronize from "./synchronize";
 export default async function executionHandler(
   context: IntegrationExecutionContext,
 ): Promise<IntegrationExecutionResult> {
-  return { operations: await synchronize(context) };
+  try {
+    const operations = await synchronize(context);
+    return { operations };
+  } catch (err) {
+    if (err.code === "ETIMEDOUT") {
+      throw new IntegrationError({
+        cause: err,
+        expose: true,
+        message: "Failed to synchronize on connection timeout",
+      });
+    } else {
+      throw err;
+    }
+  }
 }


### PR DESCRIPTION
When the server times out completely, a case unhandled by the snyk-client, report a warning and allow the integration to complete without crashing. It can recover during the next invocation.