### PR TITLE
Use aggregated list endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- Use the `/aggregated-issues` endpoint to list issues, which is recommended by
+  Snyk, rather than the deprecated `/issues` endpoint.
+
 ## 2.0.5 - 2021-08-18
 
 ### Fixed

--- a/src/@jupiterone/snyk-client.d.ts
+++ b/src/@jupiterone/snyk-client.d.ts
@@ -1,1 +1,13 @@
-declare module '@jupiterone/snyk-client';
+declare module '@jupiterone/snyk-client' {
+  export default class SnykModule {
+    constructor(apiKey: string, options?: { retries?: number });
+
+    verifyAccess(orgId: string);
+
+    listAllProjects(orgId: string);
+
+    listIssues(orgId: string, projectId: string, filters?: any);
+
+    listAggregatedIssues(orgId: string, projectId: string, filters?: any);
+  }
+}

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -1,11 +1,12 @@
 import {
   Entity,
+  parseTimePropertyValue,
   Relationship,
   RelationshipDirection,
 } from '@jupiterone/integration-sdk-core';
 import { Entities, Relationships } from './constants';
 
-import { CVEEntity, CWEEntity, FindingEntity, SnykVulnIssue } from './types';
+import { AggregatedIssue, CVEEntity, CWEEntity, FindingEntity } from './types';
 
 export const SNYK_SERVICE_ENTITY_TYPE = 'snyk_account';
 export const SNYK_FINDING_ENTITY_TYPE = 'snyk_finding';
@@ -19,10 +20,6 @@ export const SNYK_FINDING_CWE_RELATIONSHIP_TYPE = 'snyk_finding_exploits_cwe';
 
 const CVE_URL_BASE = 'https://nvd.nist.gov/vuln/detail/';
 
-function getTime(time: Date | string): number {
-  return new Date(time).getTime();
-}
-
 export function createServiceEntity(orgId: string): Entity {
   return {
     _key: `snyk:${orgId}`,
@@ -33,39 +30,40 @@ export function createServiceEntity(orgId: string): Entity {
   };
 }
 
-export function createFindingEntity(vuln: SnykVulnIssue): FindingEntity {
+export function createFindingEntity(vuln: AggregatedIssue): FindingEntity {
   return {
     _class: Entities.SNYK_FINDING._class,
     _key: `snyk-project-finding-${vuln.id}`,
     _type: Entities.SNYK_FINDING._type,
     category: 'application',
-    score: vuln.cvssScore,
-    cvssScore: vuln.cvssScore,
-    cwe: vuln.identifiers.CWE,
-    cve: vuln.identifiers.CVE,
-    description: vuln.description,
-    displayName: vuln.title,
-    webLink: vuln.url,
+    score: vuln.issueData.cvssScore,
+    cvssScore: vuln.issueData.cvssScore,
+    cwe: vuln.issueData.identifiers?.CWE,
+    cve: vuln.issueData.identifiers?.CVE,
+    description: vuln.issueData.description,
+    displayName: vuln.issueData.title,
+    webLink: vuln.issueData.url,
     id: vuln.id,
-    numericSeverity: vuln.cvssScore,
-    severity: vuln.severity,
-    from: vuln.from,
-    package: vuln.package,
-    version: vuln.version,
-    language: vuln.language,
-    packageManager: vuln.packageManager,
-    isUpgradable: vuln.isUpgradable,
-    isPatchable: vuln.isPatchable,
-    publicationTime: getTime(vuln.publicationTime),
-    disclosureTime: getTime(vuln.disclosureTime),
+    numericSeverity: vuln.issueData.cvssScore,
+    severity: vuln.issueData.severity,
+    pkgName: vuln.pkgName,
+    pkgVersions: vuln.pkgVersions,
+    language: vuln.issueData.language,
+    isUpgradable: vuln.fixInfo?.isUpgradable,
+    isPatchable: vuln.fixInfo?.isPatchable,
+    publicationTime: parseTimePropertyValue(vuln.issueData.publicationTime),
+    disclosureTime: parseTimePropertyValue(vuln.issueData.disclosureTime),
     open: true,
     targets: [],
-    type: vuln.type,
+    issueType: vuln.issueType,
     identifiedInFile: '',
   };
 }
 
-export function createCVEEntity(cve: string, cvssScore: number): CVEEntity {
+export function createCVEEntity(
+  cve: string,
+  cvssScore: number | string,
+): CVEEntity {
   const cveLowerCase = cve.toLowerCase();
   const cveUpperCase = cve.toUpperCase();
   const link = CVE_URL_BASE + cveUpperCase;

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -5,62 +5,22 @@ import {
 } from '@jupiterone/integration-sdk-core';
 import { Entities, Relationships } from './constants';
 
-import { CVEEntity, CWEEntity, FindingEntity } from './types';
+import { CVEEntity, CWEEntity, FindingEntity, SnykVulnIssue } from './types';
+
+export const SNYK_SERVICE_ENTITY_TYPE = 'snyk_account';
+export const SNYK_FINDING_ENTITY_TYPE = 'snyk_finding';
+export const SNYK_CVE_ENTITY_TYPE = 'cve';
+export const SNYK_CWE_ENTITY_TYPE = 'cwe';
+
+export const SNYK_SERVICE_SNYK_FINDING_RELATIONSHIP_TYPE =
+  'snyk_service_identified_snyk_finding';
+export const SNYK_FINDING_CVE_RELATIONSHIP_TYPE = 'snyk_finding_is_cve';
+export const SNYK_FINDING_CWE_RELATIONSHIP_TYPE = 'snyk_finding_exploits_cwe';
 
 const CVE_URL_BASE = 'https://nvd.nist.gov/vuln/detail/';
 
 function getTime(time: Date | string): number {
   return new Date(time).getTime();
-}
-
-export interface SnykVulnIssue {
-  id: string;
-  url: string;
-  title: string;
-  type: string;
-  description: string;
-  from: string[];
-  package: string;
-  version: string;
-  severity: string;
-  language: string;
-  packageManager: string;
-  publicationTime: Date;
-  disclosureTime: Date;
-  isUpgradable: string;
-  isPatchable: string;
-  identifiers: Identifier;
-  cvssScore: number;
-  patches: Patch[];
-  upgradePath: string[];
-}
-
-export interface Identifier {
-  CVE: string[];
-  CWE: string[];
-}
-
-export interface Patch {
-  id: string;
-  urls: string[];
-  version: string;
-  comments: string[];
-  modificationTime: Date;
-}
-
-export interface Project {
-  name: string;
-  id: string;
-  createdOn: Date;
-  origin: string;
-  totalDependencies: number;
-  issueCountsBySeverity: IssueCount;
-}
-
-export interface IssueCount {
-  low: number;
-  medium: number;
-  high: number;
 }
 
 export function createServiceEntity(orgId: string): Entity {

--- a/src/steps/fetchFindings.ts
+++ b/src/steps/fetchFindings.ts
@@ -70,10 +70,10 @@ const step: IntegrationStep<IntegrationConfig> = {
           finding.identifiedInFile = packageName;
           entityCache.findingEntities[finding.id] = finding;
 
-          for (const cve of finding.cve) {
+          for (const cve of finding.cve || []) {
             let cveEntity = entityCache.cveEntities[cve];
             if (!cveEntity) {
-              cveEntity = createCVEEntity(cve, issue.cvssScore);
+              cveEntity = createCVEEntity(cve, issue.issueData.cvssScore!);
               entityCache.cveEntities[cve] = cveEntity;
             }
             await jobState.addRelationship(
@@ -81,7 +81,7 @@ const step: IntegrationStep<IntegrationConfig> = {
             );
           }
 
-          for (const cwe of finding.cwe) {
+          for (const cwe of finding.cwe || []) {
             let cweEntity = entityCache.cweEntities[cwe];
             if (!cweEntity) {
               cweEntity = createCWEEntity(cwe);

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,3 +45,53 @@ export interface CWEEntity {
   webLink: string;
   [k: string]: string | string[];
 };
+
+export interface SnykVulnIssue {
+  id: string;
+  url: string;
+  title: string;
+  type: string;
+  description: string;
+  from: string[];
+  package: string;
+  version: string;
+  severity: string;
+  language: string;
+  packageManager: string;
+  publicationTime: Date;
+  disclosureTime: Date;
+  isUpgradable: string;
+  isPatchable: string;
+  identifiers: Identifier;
+  cvssScore: number;
+  patches: Patch[];
+  upgradePath: string[];
+}
+
+interface Identifier {
+  CVE: string[];
+  CWE: string[];
+}
+
+interface Patch {
+  id: string;
+  urls: string[];
+  version: string;
+  comments: string[];
+  modificationTime: Date;
+}
+
+export interface Project {
+  name: string;
+  id: string;
+  createdOn: Date;
+  origin: string;
+  totalDependencies: number;
+  issueCountsBySeverity: IssueCount;
+}
+
+interface IssueCount {
+  low: number;
+  medium: number;
+  high: number;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,8 +18,8 @@ export interface IntegrationConfig extends IntegrationInstanceConfig {
  */
 export type FindingEntity = Entity & {
   id: string;
-  cve: string[];
-  cwe: string[];
+  cve?: string[];
+  cwe?: string[];
   targets: string[];
 };
 
@@ -29,7 +29,7 @@ export interface CVEEntity {
   _type: string;
   name: string;
   displayName: string;
-  cvssScore: number;
+  cvssScore: string | number;
   references: string[];
   webLink: string;
   [k: string]: string | string[] | number;
@@ -46,39 +46,76 @@ export interface CWEEntity {
   [k: string]: string | string[];
 };
 
-export interface SnykVulnIssue {
+/**
+ * These properties were manually written based on Snyk API docs.
+ * See https://snyk.docs.apiary.io/#reference/projects/aggregated-project-issues/list-all-aggregated-issues
+ */
+export interface AggregatedIssue {
   id: string;
-  url: string;
-  title: string;
-  type: string;
-  description: string;
-  from: string[];
-  package: string;
-  version: string;
-  severity: string;
-  language: string;
-  packageManager: string;
-  publicationTime: Date;
-  disclosureTime: Date;
-  isUpgradable: string;
-  isPatchable: string;
-  identifiers: Identifier;
-  cvssScore: number;
-  patches: Patch[];
-  upgradePath: string[];
-}
-
-interface Identifier {
-  CVE: string[];
-  CWE: string[];
-}
-
-interface Patch {
-  id: string;
-  urls: string[];
-  version: string;
-  comments: string[];
-  modificationTime: Date;
+  issueType: 'vuln' | 'license';
+  pkgName: string;
+  pkgVersions: string[];
+  issueData: {
+    id: string;
+    title: string;
+    severity: string;
+    originalSeverity: string;
+    url: string;
+    description?: string;
+    identifiers?: {
+      CVE?: string[];
+      CWE?: string[];
+      OSVDB?: string[];
+    };
+    credit?: string[];
+    exploitMaturity: string;
+    semver?: {
+      vulnerable?: string;
+      unaffected?: string;
+    };
+    publicationTime?: string;
+    disclosureTime?: string;
+    CVSSv3?: string;
+    cvssScore?: string;
+    language?: string;
+    patches?: {
+      id?: string;
+      urls?: string[];
+      version?: string;
+      comments?: string[];
+      modificationTime?: string;
+    }[];
+    nearestFixedInVersion?: string;
+  };
+  introducedThrough?: {
+    kind: string;
+    data: any;
+  }[];
+  isPatched: boolean;
+  isIgnored: boolean;
+  ignoreReasons?: {
+    reason?: string;
+    expires?: string;
+    source?: 'cli' | 'api' | string;
+  }[];
+  fixInfo?: {
+    isUpgradable?: boolean;
+    isPinnable?: boolean;
+    isPatchable?: boolean;
+    isPartiallyFixable?: boolean;
+    nearestFixedInVersion?: string;
+    fixedIn?: string[];
+  };
+  priority?: {
+    score?: number;
+    factors?: {
+      name?: string;
+      description?: string;
+    }[];
+  };
+  links?: {
+    paths?: string;
+  };
 }
 
 export interface Project {


### PR DESCRIPTION
```
### Changed

- Use the `/aggregated-issues` endpoint to list issues, which is recommended by
  Snyk, rather than the deprecated `/issues` endpoint.
```

I'm still waiting on word from the user who ran into `500`s on this endpoint to see whether switching to this endpoint will fix it.