### PR TITLE
Isolate fetch-account step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to
 
 - Added Snyk integration spec - see `./docs/spec/index.ts`
 
+### Changed
+
+- Isolated `fetch-account` step
+
 ## [2.1.1] - 2021-08-23
 
 ### Fixed

--- a/docs/spec/src/index.ts
+++ b/docs/spec/src/index.ts
@@ -12,18 +12,17 @@ export const invocationConfig: IntegrationSpecConfig<IntegrationConfig> = {
        * ENDPOINT: GET https://snyk.io/api/v1/org/{orgId}/settings
        * PATTERN: Singleton
        */
-      id: 'fetch-organization',
-      name: 'Fetch Organization',
+      id: 'fetch-account',
+      name: 'Fetch Account',
       entities: [
         {
-          resourceName: 'Snyk Organization',
-          _type: 'snyk_organization',
-          _class: 'Account',
+          resourceName: 'Snyk Account',
+          _type: 'snyk_account',
+          _class: ['Service', 'Account'],
         },
       ],
       relationships: [],
-      dependsOn: [],
-      implemented: false,
+      implemented: true,
     },
     {
       /**

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,14 @@
 import { RelationshipClass } from '@jupiterone/integration-sdk-core';
 
+export const SetDataKeys = {
+  ACCOUNT_ENTITY: 'ACCOUNT_ENTITY',
+};
+
+export const StepIds = {
+  FETCH_ACCOUNT: 'fetch-account',
+  FETCH_FINDINGS: 'fetch-findings',
+};
+
 export const Entities = {
   CVE: {
     _type: 'cve',

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,12 @@
 import { IntegrationInvocationConfig } from '@jupiterone/integration-sdk-core';
 
 import instanceConfigFields from './instanceConfigFields';
-import fetchFindings from './steps/fetchFindings';
+import { steps } from './steps/fetchFindings';
 import { IntegrationConfig } from './types';
 import validateInvocation from './validateInvocation';
 
 export const invocationConfig: IntegrationInvocationConfig<IntegrationConfig> = {
   instanceConfigFields,
   validateInvocation,
-  integrationSteps: [fetchFindings],
+  integrationSteps: steps,
 };


### PR DESCRIPTION
Isolated the `fetch-account` step to move this integration towards more atomic steps. Also did so in order to set the `fetch-account` spec to `implemented: true`.

```
### Changed

- Isolated `fetch-account` step