### PR TITLE
INT-4853 - Add new properties to `snyk_project`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [2.4.0] - 2022-08-15
+
+### Added
+
+- New properties added to entities:
+
+  | Entity         | Properties         |
+  | -------------- | ------------------ |
+  | `snyk_project` | `repoFullName`     |
+  | `snyk_project` | `repoOrganization` |
+  | `snyk_project` | `repoName`         |
+  | `snyk_project` | `directoryName`    |
+  | `snyk_project` | `fileName`         |
+
 ## [2.3.0] - 2022-08-12
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-snyk",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "A JupiterOne integration for Snyk.",
   "license": "MPL-2.0",
   "main": "dist/index.js",

--- a/src/steps/projects/codeRepo.test.ts
+++ b/src/steps/projects/codeRepo.test.ts
@@ -21,24 +21,55 @@ describe('#parseSnykProjectName', () => {
   test('should return parsed Snyk project when full file path supplied', () => {
     expect(parseSnykProjectName('starbase-test/starbase:package.json')).toEqual(
       {
-        codeRepoOrgName: 'starbase-test',
-        codeRepoName: 'starbase',
+        repoFullName: 'starbase-test/starbase',
+        repoOrganization: 'starbase-test',
+        repoName: 'starbase',
+        directoryName: undefined,
+        fileName: 'package.json',
       },
     );
   });
 
   test('should return parsed Snyk project when project without file path supplied', () => {
     expect(parseSnykProjectName('starbase-test/starbase')).toEqual({
-      codeRepoOrgName: 'starbase-test',
-      codeRepoName: 'starbase',
+      repoFullName: 'starbase-test/starbase',
+      repoOrganization: 'starbase-test',
+      repoName: 'starbase',
+      directoryName: undefined,
+      fileName: undefined,
     });
   });
 
   test('should return undefined when no org name found', () => {
-    expect(parseSnykProjectName('')).toEqual(undefined);
+    expect(parseSnykProjectName('')).toEqual({
+      repoFullName: undefined,
+      repoOrganization: undefined,
+      repoName: undefined,
+      directoryName: undefined,
+      fileName: undefined,
+    });
+  });
+
+  test('should parse subdirectory information', () => {
+    // starbase-test/starbase:subdir/package.json
+    expect(
+      parseSnykProjectName('starbase-test/starbase:subdir/package.json'),
+    ).toEqual({
+      repoFullName: 'starbase-test/starbase',
+      repoOrganization: 'starbase-test',
+      repoName: 'starbase',
+      directoryName: 'subdir',
+      fileName: 'package.json',
+    });
   });
 
   test('should return undefined when no repo name found', () => {
-    expect(parseSnykProjectName('starbase')).toEqual(undefined);
+    expect(parseSnykProjectName('starbase')).toEqual({
+      repoFullName: undefined,
+      repoOrganization: undefined,
+      repoName: undefined,
+      directoryName: undefined,
+      fileName: undefined,
+    });
   });
 });

--- a/src/steps/projects/codeRepo.ts
+++ b/src/steps/projects/codeRepo.ts
@@ -9,16 +9,93 @@ function isSupportedCodeRepoOrigin(projectOrigin: string): boolean {
   );
 }
 
-function parseSnykProjectName(projectName: string) {
-  const [codeRepoProjectFullName, _] = projectName.split(':');
-  const [codeRepoOrgName, codeRepoName] = codeRepoProjectFullName.split('/');
+function parseSnykProjectFileScannedPath(fileScannedPath: string) {
+  // Two possible cases:
+  //
+  // `subdir/package.json` => ['subdir', 'package.json']
+  // `package.json` => ['package.json']
+  const fileScannedPathSplit = fileScannedPath.split('/');
 
-  return codeRepoOrgName && codeRepoName
-    ? {
-        codeRepoOrgName,
-        codeRepoName,
-      }
-    : undefined;
+  let directoryName: string | undefined;
+  let fileName: string | undefined;
+
+  if (fileScannedPathSplit.length === 2) {
+    [directoryName, fileName] = fileScannedPathSplit;
+  } else {
+    [fileName] = fileScannedPathSplit;
+  }
+
+  return {
+    directoryName,
+    fileName,
+  };
+}
+
+type ParseSnykProjectNameResult = {
+  repoFullName?: string;
+  repoOrganization?: string;
+  repoName?: string;
+  directoryName?: string;
+  fileName?: string;
+};
+
+function getUnknownSnykProjectNameParseResult(): ParseSnykProjectNameResult {
+  // Some unknown format for projects that clearly doesn't match the
+  // traditional code repo format
+  return {
+    repoFullName: undefined,
+    repoOrganization: undefined,
+    repoName: undefined,
+    directoryName: undefined,
+    fileName: undefined,
+  };
+}
+
+/**
+ * Parses a Snyk project into several different properties
+ *
+ * Example input: `starbase-test/starbase:subdir/package.json`
+ * Example output:
+ *
+ * {
+ *   repoFullName: 'starbase-test/starbase',
+ *   repoOrganization: 'starbase-test',
+ *   repoName: 'starbase',
+ *   directoryName: 'subdir',
+ *   fileName: 'package.json'
+ * }
+ */
+function parseSnykProjectName(projectName: string): ParseSnykProjectNameResult {
+  // `projectName` can be in two different formats:
+  // Input 1. `starbase-test/starbase:subdir/package.json`
+  // Input 2. `starbase-test/starbase:package.json`
+  //
+  // Output 1. ['starbase-test/starbase', 'subdir/package.json']
+  // Output 2. ['starbase-test/starbase', 'package.json']
+  const [repoFullName, fileScannedPath] = projectName.split(':');
+  if (!repoFullName) return getUnknownSnykProjectNameParseResult();
+
+  // `starbase-test/starbase` => `starbase`
+  const [repoOrganization, repoName] = repoFullName.split('/');
+  if (!repoOrganization || !repoName)
+    return getUnknownSnykProjectNameParseResult();
+
+  let directoryName: string | undefined;
+  let fileName: string | undefined;
+
+  if (fileScannedPath) {
+    ({ directoryName, fileName } = parseSnykProjectFileScannedPath(
+      fileScannedPath,
+    ));
+  }
+
+  return {
+    repoFullName: repoFullName.toLowerCase(),
+    repoOrganization: repoOrganization.toLowerCase(),
+    repoName: repoName.toLocaleLowerCase(),
+    directoryName: directoryName?.toLowerCase(),
+    fileName,
+  };
 }
 
 export { isSupportedCodeRepoOrigin, parseSnykProjectName };

--- a/src/steps/projects/codeRepo.ts
+++ b/src/steps/projects/codeRepo.ts
@@ -92,7 +92,7 @@ function parseSnykProjectName(projectName: string): ParseSnykProjectNameResult {
   return {
     repoFullName: repoFullName.toLowerCase(),
     repoOrganization: repoOrganization.toLowerCase(),
-    repoName: repoName.toLocaleLowerCase(),
+    repoName: repoName.toLowerCase(),
     directoryName: directoryName?.toLowerCase(),
     fileName,
   };


### PR DESCRIPTION
Improved Snyk project name parser to allow for new properties to
be added on `snyk_project`

- New properties added to entities:

  | Entity         | Properties         |
  | -------------- | ------------------ |
  | `snyk_project` | `repoFullName`     |
  | `snyk_project` | `repoOrganization` |
  | `snyk_project` | `repoName`         |
  | `snyk_project` | `directoryName`    |
  | `snyk_project` | `fileName`         |