### PR TITLE
INT-5335 - Fix Snyk project name parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [2.4.1] - 2022-09-03
+
+### Added
+
+- New properties added to entities:
+
+  | Entity         | Properties              |
+  | -------------- | ----------------------- |
+  | `snyk_project` | `fullDirectoryPath`     |
+  | `snyk_project` | `topLevelDirectoryName` |
+
+### Fixed
+
+- Update Snyk project name parsing to properly extract the top-level directory
+  name and the full directory path to the scanned file
+
 ## [2.4.0] - 2022-08-15
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-snyk",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "A JupiterOne integration for Snyk.",
   "license": "MPL-2.0",
   "main": "dist/index.js",

--- a/src/steps/projects/codeRepo.test.ts
+++ b/src/steps/projects/codeRepo.test.ts
@@ -58,7 +58,23 @@ describe('#parseSnykProjectName', () => {
       repoFullName: 'starbase-test/starbase',
       repoOrganization: 'starbase-test',
       repoName: 'starbase',
-      directoryName: 'subdir',
+      fullDirectoryPath: 'subdir',
+      topLevelDirectoryName: 'subdir',
+      fileName: 'package.json',
+    });
+  });
+
+  test('should handle multiple subdirectories', () => {
+    expect(
+      parseSnykProjectName(
+        'starbase-test/starbase:my-directory/sub-dir-1/sub-dir-2/package.json',
+      ),
+    ).toEqual({
+      repoFullName: 'starbase-test/starbase',
+      repoOrganization: 'starbase-test',
+      repoName: 'starbase',
+      fullDirectoryPath: 'my-directory/sub-dir-1/sub-dir-2',
+      topLevelDirectoryName: 'my-directory',
       fileName: 'package.json',
     });
   });

--- a/src/steps/projects/converter.ts
+++ b/src/steps/projects/converter.ts
@@ -14,7 +14,8 @@ export function createProjectEntity(project: any) {
     repoOrganization,
     repoName,
     repoFullName,
-    directoryName,
+    fullDirectoryPath,
+    topLevelDirectoryName,
     fileName,
   } = parseSnykProjectName(project.name);
 
@@ -30,7 +31,9 @@ export function createProjectEntity(project: any) {
         repoFullName,
         repoOrganization,
         repoName,
-        directoryName,
+        directoryName: topLevelDirectoryName,
+        topLevelDirectoryName,
+        fullDirectoryPath,
         fileName,
 
         displayName: project.name as string,


### PR DESCRIPTION
- New properties added to entities:

  | Entity         | Properties              |
  | -------------- | ----------------------- |
  | `snyk_project` | `fullDirectoryPath`     |
  | `snyk_project` | `topLevelDirectoryName` |

- Update Snyk project name parsing to properly extract the top-level directory
  name and the full directory path to the scanned file