### PR TITLE
INT-3169 - Use pkgName as display name for snyk_issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- `snyk_finding` display name to use package name
+
 ## [2.4.2] - 2022-11-30
 
 ### Changed

--- a/src/steps/findings/converters.ts
+++ b/src/steps/findings/converters.ts
@@ -64,7 +64,7 @@ export function createFindingEntity(vuln: any, projectEntity: Entity) {
         cve: vuln.issueData.identifiers?.CVE,
         description: vuln.issueData.description,
         name: vuln.issueData.title,
-        displayName: vuln.issueData.title,
+        displayName: vuln.pkgName,
         webLink: vuln.issueData.url,
         id: vuln.id,
         numericSeverity: getNumericSeverityFromIssueSeverity(


### PR DESCRIPTION
Used Snyk's UI as reference

- `snyk_finding` display name to use package name

Given the following:
```
"id": "SNYK-DEBIAN9-SYSTEMD-305135",
"pkgName": "systemd/libsystemd0",
"title": "Improper Privilege Management",
```
Originally the `title` value was used for name/displayName.
Currently we've set it to use `pkgName` value instead considering the dashboard seems to highlight it the most. Another candidate is to perhaps use `id` value. Any thoughts regarding this?

<img width="882" alt="Screenshot 2022-12-21 at 17 10 31" src="https://user-images.githubusercontent.com/13102652/208870652-9f5baefe-7dd3-48dd-bfc2-f8ddbc898955.png">