### PR TITLE
[INT-7625] Adding all possible repoNames to target property.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [2.7.0] - 2023-01-24
+
+- Adding multiple possible ways to relate `CodeRepo` to `snyk_finding`, this way
+  we won't break any exising relationship while fixing `gitlab_project` ones.
+
 ## [2.6.0] - 2023-01-24
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-snyk",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "A JupiterOne integration for Snyk.",
   "license": "MPL-2.0",
   "main": "dist/index.js",

--- a/src/steps/findings/converters.ts
+++ b/src/steps/findings/converters.ts
@@ -61,9 +61,10 @@ export function createFindingEntity(
   logger: IntegrationLogger,
 ) {
   //subdir_1/subdir_2/name
-  const { repoName, repoFullName } = parseSnykProjectName(project.name);
-  const last = repoFullName?.split('/').pop();
-  const targets: string[] = [repoName, repoFullName, last].filter(
+  const { repoName, repoFullName, repoLastPath } = parseSnykProjectName(
+    project.name,
+  );
+  const targets: string[] = [repoName, repoFullName, repoLastPath].filter(
     (name) => name !== undefined,
   ) as string[];
 

--- a/src/steps/findings/converters.ts
+++ b/src/steps/findings/converters.ts
@@ -9,9 +9,10 @@ import {
 import { Entities, mappedRelationships, Relationships } from '../../constants';
 import { Priority, SnykFinding } from '../../types/finding';
 
-import { CVEEntity, CWEEntity } from '../../types/types';
+import { CVEEntity, CWEEntity, Project } from '../../types/types';
 
 import { deconstructDesc } from '../../util/deconstructDesc';
+import { parseSnykProjectName } from '../projects/codeRepo';
 
 const CVE_URL_BASE = 'https://nvd.nist.gov/vuln/detail/';
 
@@ -56,12 +57,15 @@ function getSeverityFromPriorities(s: Priority | undefined) {
 export function createFindingEntity(
   projectId: string,
   vuln: SnykFinding,
-  projectEntity: Entity,
+  project: Project,
   logger: IntegrationLogger,
 ) {
-  const targets = projectEntity.repoName
-    ? [projectEntity.repoName as string]
-    : [];
+  //subdir_1/subdir_2/name
+  const { repoName, repoFullName } = parseSnykProjectName(project.name);
+
+  const last = repoFullName?.split('/').pop();
+
+  const targets = [repoName, repoFullName, last];
 
   // TODO: severity calculation can be cleaned up and simplified. This is here for
   // debugging purposes.

--- a/src/steps/findings/converters.ts
+++ b/src/steps/findings/converters.ts
@@ -62,10 +62,10 @@ export function createFindingEntity(
 ) {
   //subdir_1/subdir_2/name
   const { repoName, repoFullName } = parseSnykProjectName(project.name);
-
   const last = repoFullName?.split('/').pop();
-
-  const targets = [repoName, repoFullName, last];
+  const targets: string[] = [repoName, repoFullName, last].filter(
+    (name) => name !== undefined,
+  ) as string[];
 
   // TODO: severity calculation can be cleaned up and simplified. This is here for
   // debugging purposes.

--- a/src/steps/findings/index.ts
+++ b/src/steps/findings/index.ts
@@ -67,7 +67,7 @@ async function fetchFindings({
           const finding = createFindingEntity(
             projectId,
             issue,
-            projectEntity,
+            project,
             logger,
           ) as FindingEntity;
 

--- a/src/steps/projects/codeRepo.test.ts
+++ b/src/steps/projects/codeRepo.test.ts
@@ -23,6 +23,7 @@ describe('#parseSnykProjectName', () => {
       {
         repoFullName: 'starbase-test/starbase',
         repoOrganization: 'starbase-test',
+        repoLastPath: 'starbase',
         repoName: 'starbase',
         directoryName: undefined,
         fileName: 'package.json',
@@ -35,6 +36,7 @@ describe('#parseSnykProjectName', () => {
       repoFullName: 'starbase-test/starbase',
       repoOrganization: 'starbase-test',
       repoName: 'starbase',
+      repoLastPath: 'starbase',
       directoryName: undefined,
       fileName: undefined,
     });
@@ -43,6 +45,7 @@ describe('#parseSnykProjectName', () => {
   test('should return undefined when no org name found', () => {
     expect(parseSnykProjectName('')).toEqual({
       repoFullName: undefined,
+      repoLastPath: undefined,
       repoOrganization: undefined,
       repoName: undefined,
       directoryName: undefined,
@@ -58,6 +61,7 @@ describe('#parseSnykProjectName', () => {
       repoFullName: 'starbase-test/starbase',
       repoOrganization: 'starbase-test',
       repoName: 'starbase',
+      repoLastPath: 'starbase',
       fullDirectoryPath: 'subdir',
       topLevelDirectoryName: 'subdir',
       fileName: 'package.json',
@@ -73,8 +77,23 @@ describe('#parseSnykProjectName', () => {
       repoFullName: 'starbase-test/starbase',
       repoOrganization: 'starbase-test',
       repoName: 'starbase',
+      repoLastPath: 'starbase',
       fullDirectoryPath: 'my-directory/sub-dir-1/sub-dir-2',
       topLevelDirectoryName: 'my-directory',
+      fileName: 'package.json',
+    });
+  });
+
+  test('should handle multiple path subdirectiories', () => {
+    expect(
+      parseSnykProjectName(
+        'starbase-test/subdir1/subdir2/starbase:package.json',
+      ),
+    ).toEqual({
+      repoFullName: 'starbase-test/subdir1/subdir2/starbase',
+      repoOrganization: 'starbase-test',
+      repoName: 'subdir1',
+      repoLastPath: 'starbase',
       fileName: 'package.json',
     });
   });

--- a/src/steps/projects/codeRepo.ts
+++ b/src/steps/projects/codeRepo.ts
@@ -49,6 +49,13 @@ type ParseSnykProjectNameResult = {
   repoOrganization?: string;
   repoName?: string;
   /**
+   * The last path to the directory wich does NOT contain the scanned file
+   *
+   *  Example scanned file: `my/directory/path:package.json`
+   *  Example `repoLastPath`: `path`
+   */
+  repoLastPath?: string;
+  /**
    * The full path to the directory which contains the scanned file
    *
    * Example scanned file: `my/directory/path/package.json`
@@ -75,6 +82,7 @@ function getUnknownSnykProjectNameParseResult(): ParseSnykProjectNameResult {
     fullDirectoryPath: undefined,
     topLevelDirectoryName: undefined,
     fileName: undefined,
+    repoLastPath: undefined,
   };
 }
 
@@ -126,6 +134,7 @@ function parseSnykProjectName(projectName: string): ParseSnykProjectNameResult {
     fullDirectoryPath: fullDirectoryPath?.toLowerCase(),
     topLevelDirectoryName: topLevelDirectoryName?.toLowerCase(),
     fileName,
+    repoLastPath: repoFullName.split('/').pop()?.toLowerCase(),
   };
 }
 


### PR DESCRIPTION
Adding multiple possible ways to relate `CodeRepo` to `snyk_finding`, this way we won't break any exising relationship while fixing `gitlab_project` ones.